### PR TITLE
SEO - Add English Language as meta element to head - Bing Search tip

### DIFF
--- a/404.html
+++ b/404.html
@@ -36,6 +36,7 @@
 		<meta name="theme-color" content="#8ECC48">
 		<meta name="apple-mobile-web-app-capable" content="yes">
 		<meta name="mobile-web-app-capable" content="yes">
+		<meta http-equiv="content-language" content="en">
 	</head>
 	<body class="loading">
 		<div id="wrapper">

--- a/_public/404.html
+++ b/_public/404.html
@@ -36,6 +36,7 @@
 		<meta name="theme-color" content="#8ECC48">
 		<meta name="apple-mobile-web-app-capable" content="yes">
 		<meta name="mobile-web-app-capable" content="yes">
+		<meta http-equiv="content-language" content="en">
 	</head>
 	<body class="loading">
 		<div id="wrapper">

--- a/_public/index.html
+++ b/_public/index.html
@@ -36,6 +36,7 @@
 		<meta name="theme-color" content="#8ECC48">
 		<meta name="apple-mobile-web-app-capable" content="yes">
 		<meta name="mobile-web-app-capable" content="yes">
+		<meta http-equiv="content-language" content="en">
 	</head>
 	<body class="loading">
 		<div id="wrapper">

--- a/_public/travel-photos/_layout.ejs
+++ b/_public/travel-photos/_layout.ejs
@@ -61,6 +61,7 @@
 		<meta name="theme-color" content="#8ECC48">
 		<meta name="apple-mobile-web-app-capable" content="yes">
 		<meta name="mobile-web-app-capable" content="yes">
+		<meta http-equiv="content-language" content="en"><% // Bing Search SEO Tip %>
 	</head>
 	<body class="is-loading">
 

--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
 		<meta name="theme-color" content="#8ECC48">
 		<meta name="apple-mobile-web-app-capable" content="yes">
 		<meta name="mobile-web-app-capable" content="yes">
+		<meta http-equiv="content-language" content="en">
 	</head>
 	<body class="loading">
 		<div id="wrapper">

--- a/travel-photos/cucumber-coffee-cafe-klodzko-poland/index.html
+++ b/travel-photos/cucumber-coffee-cafe-klodzko-poland/index.html
@@ -53,6 +53,7 @@
 		<meta name="theme-color" content="#8ECC48">
 		<meta name="apple-mobile-web-app-capable" content="yes">
 		<meta name="mobile-web-app-capable" content="yes">
+		<meta http-equiv="content-language" content="en">
 	</head>
 	<body class="is-loading">
 

--- a/travel-photos/eat-street-rabbit-beijing-china/index.html
+++ b/travel-photos/eat-street-rabbit-beijing-china/index.html
@@ -51,6 +51,7 @@
 		<meta name="theme-color" content="#8ECC48">
 		<meta name="apple-mobile-web-app-capable" content="yes">
 		<meta name="mobile-web-app-capable" content="yes">
+		<meta http-equiv="content-language" content="en">
 	</head>
 	<body class="is-loading">
 

--- a/travel-photos/elephant-orphanage-sri-lanka/index.html
+++ b/travel-photos/elephant-orphanage-sri-lanka/index.html
@@ -53,6 +53,7 @@
 		<meta name="theme-color" content="#8ECC48">
 		<meta name="apple-mobile-web-app-capable" content="yes">
 		<meta name="mobile-web-app-capable" content="yes">
+		<meta http-equiv="content-language" content="en">
 	</head>
 	<body class="is-loading">
 

--- a/travel-photos/folk-music-yerevan-armenia/index.html
+++ b/travel-photos/folk-music-yerevan-armenia/index.html
@@ -53,6 +53,7 @@
 		<meta name="theme-color" content="#8ECC48">
 		<meta name="apple-mobile-web-app-capable" content="yes">
 		<meta name="mobile-web-app-capable" content="yes">
+		<meta http-equiv="content-language" content="en">
 	</head>
 	<body class="is-loading">
 

--- a/travel-photos/index.html
+++ b/travel-photos/index.html
@@ -43,6 +43,7 @@
 		<meta name="theme-color" content="#8ECC48">
 		<meta name="apple-mobile-web-app-capable" content="yes">
 		<meta name="mobile-web-app-capable" content="yes">
+		<meta http-equiv="content-language" content="en">
 	</head>
 	<body class="is-loading">
 

--- a/travel-photos/mystery-of-japanese-onsen/index.html
+++ b/travel-photos/mystery-of-japanese-onsen/index.html
@@ -51,6 +51,7 @@
 		<meta name="theme-color" content="#8ECC48">
 		<meta name="apple-mobile-web-app-capable" content="yes">
 		<meta name="mobile-web-app-capable" content="yes">
+		<meta http-equiv="content-language" content="en">
 	</head>
 	<body class="is-loading">
 

--- a/travel-photos/streamer-ooboke-koboke-river-japan/index.html
+++ b/travel-photos/streamer-ooboke-koboke-river-japan/index.html
@@ -53,6 +53,7 @@
 		<meta name="theme-color" content="#8ECC48">
 		<meta name="apple-mobile-web-app-capable" content="yes">
 		<meta name="mobile-web-app-capable" content="yes">
+		<meta http-equiv="content-language" content="en">
 	</head>
 	<body class="is-loading">
 


### PR DESCRIPTION
Bing Search SEO tip "The Meta Language information is used as a hint to help us understand the intended language and country/region the page content applies to. This can help if your site is not hosted in the country/region. "
